### PR TITLE
Update env-rosa.sh

### DIFF
--- a/operators/env-rosa.sh
+++ b/operators/env-rosa.sh
@@ -1,6 +1,6 @@
 export CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.apiServerURL}" | awk -F '.' '{print $2}')
 export HYPERSCALER_STORAGE_SECRET_TYPE=s3
-export HYPERSCALER_STORAGE_CLASS=gp3
+export HYPERSCALER_STORAGE_CLASS=gp3-csi
 
 # Get Loki bucket in S3
 get_aws_bucket() {


### PR DESCRIPTION
The gp3 storage class, which was the same as gp3-csi has been removed from the SC built-in manifest in the latest ROSA versions.