### PR TITLE
Update env-rosa.sh

### DIFF
--- a/operators/env-rosa.sh
+++ b/operators/env-rosa.sh
@@ -1,6 +1,7 @@
 export CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.apiServerURL}" | awk -F '.' '{print $2}')
 export HYPERSCALER_STORAGE_SECRET_TYPE=s3
 export HYPERSCALER_STORAGE_CLASS=gp3-csi
+export AWS_PAGER=""
 
 # Get Loki bucket in S3
 get_aws_bucket() {


### PR DESCRIPTION
AWS Pager stops script when an apply after the first creation has to be performed. Disabling it during script execution is recomomended.